### PR TITLE
feat: add toggles for visibility of Lutris and Steam Logomenu items.

### DIFF
--- a/PrefsLib/adw.js
+++ b/PrefsLib/adw.js
@@ -458,7 +458,7 @@ export const LogoMenuOptionsPage = GObject.registerClass(class LogoMenuOptionsWi
 
         // Toggle Lutris visibility
         const showLutrisRow = new Adw.ActionRow({
-            title: _('Show Lutris'),
+            title: _('Show Lutris option'),
         });
 
         const showLutrisSwitch = new Gtk.Switch({
@@ -474,7 +474,7 @@ export const LogoMenuOptionsPage = GObject.registerClass(class LogoMenuOptionsWi
 
         // Toggle Steam visibility
         const showSteamRow = new Adw.ActionRow({
-            title: _('Show Steam'),
+            title: _('Show Steam option'),
         });
 
         const showSteamSwitch = new Gtk.Switch({

--- a/PrefsLib/adw.js
+++ b/PrefsLib/adw.js
@@ -456,6 +456,39 @@ export const LogoMenuOptionsPage = GObject.registerClass(class LogoMenuOptionsWi
 
         iconShadowVisibilityRow.add_suffix(iconShadowRowVisiblitySwitch);
 
+        // Toggle Lutris visibility
+        const showLutrisRow = new Adw.ActionRow({
+            title: _('Show Lutris'),
+        });
+
+        const showLutrisSwitch = new Gtk.Switch({
+            valign: Gtk.Align.CENTER,
+            active: this._settings.get_boolean('show-lutris'),
+        });
+
+        showLutrisSwitch.connect('notify::active', widget => {
+            this._settings.set_boolean('show-lutris', widget.get_active());
+        });
+
+        showLutrisRow.add_suffix(showLutrisSwitch);
+
+        // Toggle Steam visibility
+        const showSteamRow = new Adw.ActionRow({
+            title: _('Show Steam'),
+        });
+
+        const showSteamSwitch = new Gtk.Switch({
+            valign: Gtk.Align.CENTER,
+            active: this._settings.get_boolean('show-steam'),
+        });
+
+        showSteamSwitch.connect('notify::active', widget => {
+            this._settings.set_boolean('show-steam', widget.get_active());
+        });
+
+        showSteamRow.add_suffix(showSteamSwitch);
+
+
         // Pref Group
         prefGroup1.add(menuButtonIconClickTypeRow);
         prefGroup1.add(extensionsAppRow);
@@ -468,6 +501,9 @@ export const LogoMenuOptionsPage = GObject.registerClass(class LogoMenuOptionsWi
         prefGroup2.add(forceQuitOptionrow);
         prefGroup2.add(lockScreenOptionRow);
         prefGroup2.add(softwareCentreOptionRow);
+        prefGroup2.add(showLutrisRow);
+        prefGroup2.add(showSteamRow);
+
 
         prefGroup3.add(activitiesButtonVisiblityRow);
         prefGroup3.add(iconShadowVisibilityRow);

--- a/extension.js
+++ b/extension.js
@@ -41,8 +41,9 @@ class LogoMenuMenuButton extends PanelMenu.Button {
         this._settings.connectObject('changed::use-custom-icon', () => this.setIconImage(), this);
         this._settings.connectObject('changed::custom-icon-path', () => this.setIconImage(), this);
         this._settings.connectObject('changed::menu-button-icon-size', () => this.setIconSize(), this);
+
 	
-	this.hideIconShadow();
+        this.hideIconShadow();
         this.setIconImage();
         this.setIconSize();
         this.add_child(this.icon);
@@ -56,6 +57,9 @@ class LogoMenuMenuButton extends PanelMenu.Button {
         this._settings.connectObject('changed::hide-forcequit', () => this._displayMenuItems(), this);
         this._settings.connectObject('changed::show-lockscreen', () => this._displayMenuItems(), this);
         this._settings.connectObject('changed::show-activities-button', () => this._displayMenuItems(), this);
+        this._settings.connectObject('changed::show-lutris', () => this._displayMenuItems(), this);
+        this._settings.connectObject('changed::show-steam', () => this._displayMenuItems(), this);
+
         this._displayMenuItems();
 
         // bind middle click option to toggle overview
@@ -75,6 +79,9 @@ class LogoMenuMenuButton extends PanelMenu.Button {
         const showSoftwareCenter = !this._settings.get_boolean('hide-softwarecentre');
         const showWarehouse = !this._settings.get_boolean('hide-warehouse');
         const showActivitiesButton = this._settings.get_boolean('show-activities-button');
+        const showLutris = this._settings.get_boolean('show-lutris');
+        const showSteam = this._settings.get_boolean('show-steam');
+
 
         this.menu.removeAll();
 
@@ -86,9 +93,12 @@ class LogoMenuMenuButton extends PanelMenu.Button {
 
         this._addItem(new MenuItem(_('App Grid'), () => this._showAppGrid()));
         this._addItem(new MenuItem(_('Files'), () => this._openNautilus()));
-        this._addItem(new PopupMenu.PopupSeparatorMenuItem());
-        this._addItem(new MenuItem(_('Steam'), () => this._openSteam()));
-        this._addItem(new MenuItem(_('Lutris'), () => this._openLutris()));
+        if (showSteam || showLutris || showReturnToGamingMode)
+            this._addItem(new PopupMenu.PopupSeparatorMenuItem());
+        if (showSteam)
+            this._addItem(new MenuItem(_('Steam'), () => this._openSteam()));
+        if (showLutris)
+            this._addItem(new MenuItem(_('Lutris'), () => this._openLutris()));
         if (showReturnToGamingMode)
             this._addItem(new MenuItem(_('Return to Gaming Mode'), () => this._returnToGamingMode()));
 

--- a/schemas/org.gnome.shell.extensions.logo-menu.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.logo-menu.gschema.xml
@@ -63,6 +63,18 @@
       <description>Toggle return to gamemode visibility.</description>
     </key>
 
+    <key type="b" name="show-lutris">
+      <default>true</default>
+      <summary>Toggle Lutris visiblity</summary>
+      <description>Toggle Lutris visibility.</description>
+    </key>
+
+    <key type="b" name="show-steam">
+      <default>true</default>
+      <summary>Toggle Steam visiblity</summary>
+      <description>Toggle Steam visibility.</description>
+    </key>
+
     <key type="b" name="show-distroshelf">
       <default>false</default>
       <summary>Toggle DistroShelf option visibility</summary>


### PR DESCRIPTION
https://github.com/user-attachments/assets/122e0786-5826-4f5b-9941-941ce0c6014e

Probably not a terribly common request, but we had someone ask for this in the discord, and it was confusing for the user because there was no option in the menu to match the options from the non-forked logo menu to hide/show lutris or steam.

EDIT: changed the text to be a bit more consistent with the other options in that section

<img width="2084" height="1287" alt="Screenshot From 2025-09-28 17-44-27" src="https://github.com/user-attachments/assets/27c4bc98-7302-4300-848d-ee913b99adc8" />
